### PR TITLE
Fix and test c10.C10.__repr__().

### DIFF
--- a/chapter10/c10.py
+++ b/chapter10/c10.py
@@ -98,7 +98,7 @@ class C10(object):
                 self.file.seek(pos + 1)
 
     def __repr__(self):
-        return '<C10: {}>'.format(os.path.basename(self.file.name))
+        return '<C10: {}>'.format(os.path.basename(self.file.io.name))
 
     def __iter__(self):
         return self

--- a/tests/unit/test_c10.py
+++ b/tests/unit/test_c10.py
@@ -15,3 +15,8 @@ def test_next():
 def test_next_stop():
     with pytest.raises(StopIteration):
         next(c10.C10(Mock(read=Mock(side_effect=EOFError))))
+
+def test_str_repr():
+    c = c10.C10(SAMPLE)
+    repr(c)
+    str(c)


### PR DESCRIPTION
A simple fix to properly access the name of the Chapter 10 file opened by the C10 object.