### PR TITLE
Fix TimeF1 ms decoding

### DIFF
--- a/chapter10/time.py
+++ b/chapter10/time.py
@@ -115,7 +115,7 @@ such as PCM or 1553
         raw = self.buffer.read(self.data_length - 4)
         self.__dict__.update(self.data_format.unpack(raw))
 
-        ms = ((self.Hmn * 10) + self.Tmn)
+        ms = (self.Hmn * 100) + (self.Tmn * 10)
         seconds = self.Sn + (self.TSn * 10)
         minutes = self.Mn + (self.TMn * 10)
         hours = self.Hn + (self.THn * 10)

--- a/chapter10/time.py
+++ b/chapter10/time.py
@@ -108,7 +108,7 @@ such as PCM or 1553
             for name in self.data_format.names:
                 setattr(self, name, 0)
             self._initial_time = 0
-            if not self.time:
+            if getattr(self, "time", False):
                 self.time = datetime.now()
             return
 

--- a/tests/unit/test_time.py
+++ b/tests/unit/test_time.py
@@ -1,4 +1,5 @@
 
+from datetime import datetime
 import io
 
 from chapter10 import time, C10
@@ -18,3 +19,15 @@ def test_time_bytes():
             break
     raw = bytes(packet)
     assert time.TimeF1(io.BytesIO(raw)).time == packet.time
+
+
+def test_time_bytes_with_ms():
+    t0 = time.TimeF1()
+
+    # Note trailing 0, IRIG 106-15 Time F1 only allows precision
+    # to tenths of ms, but fromisoformat requires specifying to 1-ms.
+    t0.time = datetime.fromisoformat('2022-12-05 01:02:03.450')
+
+    raw = bytes(t0)
+
+    assert time.TimeF1(io.BytesIO(raw)).time == t0.time


### PR DESCRIPTION
This fixes the TimeF1 calculation of milliseconds from the component hundredths and tenths.

I opted to add a tiny new test that checks the encoding/decoding of a TimeF1 packet with non-zero milliseconds. Another option would be to modify the `sample.c10` file to have a TimeF1 packet with a non-zero milliseconds, but this potentially involved modifying a lot of other trailing packets (and reverifying any tests that use the sample fixture).

Fixes #30 