### PR TITLE
Fix TimeF1 date_format=1 Missing Month/Day

### DIFF
--- a/chapter10/time.py
+++ b/chapter10/time.py
@@ -157,6 +157,16 @@ such as PCM or 1553
 
         # Month and year format
         if self.date_format:
+            day = self.time.day
+            self.TDn = day // 10
+            day -= self.TDn * 10
+            self.Dn = day
+
+            month = self.time.month
+            self.TOn = month // 10
+            month -= self.TOn * 10
+            self.On = month
+
             year = self.time.year
             self.OYn = year // 1000
             year -= self.OYn * 1000

--- a/tests/unit/test_time.py
+++ b/tests/unit/test_time.py
@@ -22,7 +22,7 @@ def test_time_bytes():
 
 
 def test_time_bytes_with_ms():
-    t0 = time.TimeF1()
+    t0 = time.TimeF1(date_format=1)
 
     # Note trailing 0, IRIG 106-15 Time F1 only allows precision
     # to tenths of ms, but fromisoformat requires specifying to 1-ms.


### PR DESCRIPTION
Include day and month in TimeF1 packets when `date_format=1`.

Fix issue in test_time_bytes_with_ms where it defaults to `date_format=0` but the test data assumes `date_format=1`.

Fixes #32