### PR TITLE
allow Format 1 Setup Record to be 134,217,728 bytes

### DIFF
--- a/chapter10/computer.py
+++ b/chapter10/computer.py
@@ -54,6 +54,8 @@ class ComputerF1(packet.Packet):
         u1 format
         p22''')
 
+    _MAX_PACKET_BYTES = 134_217_728
+
     def __init__(self, *args, **kwargs):
         packet.Packet.__init__(self, *args, **kwargs)
         if self.buffer:

--- a/chapter10/packet.py
+++ b/chapter10/packet.py
@@ -85,6 +85,8 @@ class Packet:
 
     csdw_format = BitFormat('u32 csdw')
 
+    _MAX_PACKET_BYTES = 524288
+
     def __init__(self, file=None, parent=None, **kwargs):
 
         self.parent = parent
@@ -199,7 +201,7 @@ class Packet:
         elif self.secondary_header:
             if self.secondary_sums != self.secondary_checksum:
                 err = InvalidPacket('Secondary header checksum mismatch!')
-        if self.data_length > 524288:
+        if self.data_length > self._MAX_PACKET_BYTES:
             err = InvalidPacket(
                 f'Data length {self.data_length} larger than allowed!')
 


### PR DESCRIPTION
Updated the ComputerF1 class to allow the max packet size of 134217728 bytes according to page 10-25 of https://www.irig106.org/docs/106-15/chapter10.pdf (#34 )